### PR TITLE
Fixed DevTools rendering error when devToolsExtension is active

### DIFF
--- a/source/redux/render.js
+++ b/source/redux/render.js
@@ -102,7 +102,7 @@ export function render_on_client({ development, development_tools, create_page_e
 					<div>
 						{element}
 						{/* Since `DevTools` are inserted outside of the `<Provider/>`, provide the `store` manually */}
-						<DevTools store={store}/>
+						{!window.devToolsExtension ? <DevTools store={store} /> : null}
 					</div>
 				)
 


### PR DESCRIPTION
According to [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension#23-together-with-redux-devtools) you should not render DevTools when using devToolsExtension object.
Rendering it will cause an error:
> Warning: Failed propType: Required prop monitorState.position was not specified in DockMonitor. Check the render method of Connect(DockMonitor).