### PR TITLE
Add response headers to http client  resolve

### DIFF
--- a/source/http client.js
+++ b/source/http client.js
@@ -494,10 +494,10 @@ class Http_request
 				// then resolve with an empty result.
 				if (response.statusCode === 204)
 				{
-					return resolve()
+					return resolve(undefined, response.headers)
 				}
 
-				resolve(this.get_response_data(response))
+				resolve(this.get_response_data(response), response.headers)
 			})
 		})
 	}


### PR DESCRIPTION
We are using http client to send files to S3 bucket, which sends back information only in response headers. Unfortunately they are not accessible, because only response body is parsed and resolved with promise.

This change adds response header to resolve method.